### PR TITLE
Make mochiweb HTTP options configurable.

### DIFF
--- a/src/rabbit_mochiweb_web.erl
+++ b/src/rabbit_mochiweb_web.erl
@@ -7,12 +7,16 @@
 %% ----------------------------------------------------------------------
 
 start() ->
-    Port = case application:get_env(port) of
-        {ok, P} -> P;
-        _       -> 55672
+    PortL = case application:get_env(port) of
+        {ok, P} -> [{port, P}];
+        _       -> [{port, 55672}]
     end,
+    Options = case application:get_env(mochiweb_http_options) of
+		  {ok, L} -> L ++ PortL;
+		  _       -> PortL
+	      end,
     Loop = fun loop/1,
-    mochiweb_http:start([{name, ?MODULE}, {port, Port}, {loop, Loop}]).
+    mochiweb_http:start([{name, ?MODULE}, {loop, Loop}] ++ Options).
 
 stop() ->
     mochiweb_http:stop(?MODULE).


### PR DESCRIPTION
Previously, the only mochiweb HTTP option exposed in rabbitmq-mochiweb
was {port, N}. To make it possible to have the administrative web
interface accessible through loopback only, I wanted to add the {ip, IP}
parameter. Since there might be other mochiweb HTTP options that one
would like to set (SSL options for example), this patch makes it possible
to provide a list of options while keeping backwards compatibility with
the existing 'port' directive.

The following configurations have been tested with the expected results
(using RabbitMQ 2.4.1) :

Old :

 {rabbit_mochiweb, [{port, 50080}]}

New :

 {rabbit_mochiweb, [{mochiweb_http_options, [{ip, "127.0.0.1"}]
                   ]}

Combination :

 {rabbit_mochiweb, [{mochiweb_http_options, [{ip, "127.0.0.1"}]},
                    {port, 50080}
                   ]}
